### PR TITLE
Add Dockerfile and docker-compose to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .rspec_status
 
 Gemfile.lock
+
+Dockerfile
+docker-compose.yml


### PR DESCRIPTION
## What does this PR do?

It adds the files

```
Dockerfile
docker-compose.yml
```

to `.gitignore` to allow a docker config in local dev environments