### PR TITLE
Fix: remove development require

### DIFF
--- a/lib/apple_sign_in/helpers/jwt_conditions.rb
+++ b/lib/apple_sign_in/helpers/jwt_conditions.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: false
 
-require 'byebug'
-
 module AppleSignIn
   class JWTConditions
     include Conditions


### PR DESCRIPTION
**_Small fix:_**

As this is a development dependency, the `require` should be removed from non `development-specific` files. Otherwise when running an app with this gem it will crash since the dependency is not being required.