### PR TITLE
Feature: return validated attributes of JWT

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -115,6 +115,7 @@ detectors:
       - "/[A-Z]/"
     accept:
       - _
+      - e
   UnusedParameters:
     enabled: true
     exclude: []

--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Validate JWT token and get user information:
+
+```ruby
+# with a valid JWT
+user_id = '000343.1d22d2937c7a4e56806dfb802b06c430...'
+valid_jwt_token = 'eyJraWQiOiI4NkQ4OEtmIiwiYWxnIjoiUlMyNTYifQ.eyJpc...'
+AppleSignIn::UserIdentity.new(user_id, valid_jwt_token)
+>>  { exp: 1595279622, email: "user@example.com", email_verified: true , ...}
+
+# with an invalid JWT
+invalid_jwt_token = 'eyJraWQiOiI4NkQsd4OEtmIiwiYWxnIjoiUlMyNTYifQ.edsyJpc...'
+AppleSignIn::UserIdentity.new(user_id, invalid_jwt_token)
+>> Traceback (most recent call last):..
+>> ...
+>>  AppleSignIn::UserIdentity::JWTValidationError
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ invalid_jwt_token = 'eyJraWQiOiI4NkQsd4OEtmIiwiYWxnIjoiUlMyNTYifQ.edsyJpc...'
 AppleSignIn::UserIdentity.new(user_id, invalid_jwt_token)
 >> Traceback (most recent call last):..
 >> ...
->>  AppleSignIn::UserIdentity::JWTValidationError
+>>  AppleSignIn::Conditions::JWTValidationError
 ```
 
 ## Development

--- a/lib/apple_sign_in.rb
+++ b/lib/apple_sign_in.rb
@@ -15,6 +15,7 @@ require 'oauth2'
 
 # Files
 require 'apple_sign_in/config'
+require 'apple_sign_in/helpers/conditions/jwt_validation_error'
 
 require 'apple_sign_in/helpers/conditions/aud_condition'
 require 'apple_sign_in/helpers/conditions/exp_condition'

--- a/lib/apple_sign_in/helpers/conditions/aud_condition.rb
+++ b/lib/apple_sign_in/helpers/conditions/aud_condition.rb
@@ -7,8 +7,10 @@ module AppleSignIn
         @aud = jwt['aud']
       end
 
-      def valid?
-        @aud == AppleSignIn.config.apple_client_id
+      def validate!
+        return true if @aud == AppleSignIn.config.apple_client_id
+
+        raise JWTValidationError, 'jwt_aud is different to apple_client_id'
       end
     end
   end

--- a/lib/apple_sign_in/helpers/conditions/exp_condition.rb
+++ b/lib/apple_sign_in/helpers/conditions/exp_condition.rb
@@ -7,8 +7,10 @@ module AppleSignIn
         @exp = jwt['exp'].to_i
       end
 
-      def valid?
-        @exp > Time.now.to_i
+      def validate!
+        return true if @exp > Time.now.to_i
+
+        raise JWTValidationError, 'Expired jwt_exp'
       end
     end
   end

--- a/lib/apple_sign_in/helpers/conditions/iat_condition.rb
+++ b/lib/apple_sign_in/helpers/conditions/iat_condition.rb
@@ -7,8 +7,10 @@ module AppleSignIn
         @iat = jwt['iat'].to_i
       end
 
-      def valid?
-        @iat <= Time.now.to_i
+      def validate!
+        return true if @iat <= Time.now.to_i
+
+        raise JWTValidationError, 'jwt_iat is greater than now'
       end
     end
   end

--- a/lib/apple_sign_in/helpers/conditions/iss_condition.rb
+++ b/lib/apple_sign_in/helpers/conditions/iss_condition.rb
@@ -9,8 +9,10 @@ module AppleSignIn
         @iss = jwt['iss']
       end
 
-      def valid?
-        @iss.include?(APPLE_ISS)
+      def validate!
+        return true if @iss.include?(APPLE_ISS)
+
+        raise JWTValidationError, 'jwt_iss is different to apple_iss'
       end
     end
   end

--- a/lib/apple_sign_in/helpers/conditions/jwt_validation_error.rb
+++ b/lib/apple_sign_in/helpers/conditions/jwt_validation_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AppleSignIn
+  module Conditions
+    class JWTValidationError < StandardError; end
+  end
+end

--- a/lib/apple_sign_in/helpers/jwt_conditions.rb
+++ b/lib/apple_sign_in/helpers/jwt_conditions.rb
@@ -19,7 +19,7 @@ module AppleSignIn
     end
 
     def validate!
-      JWT::ClaimsValidator.new(decoded_jwt).validate! && validate_sub! && jwt_conditions_valid!
+      JWT::ClaimsValidator.new(decoded_jwt).validate! && validate_sub! && jwt_conditions_validate!
     rescue JWT::InvalidPayload => e
       raise JWTValidationError, e.message
     end
@@ -32,7 +32,7 @@ module AppleSignIn
       raise JWTValidationError, 'Not valid Sub'
     end
 
-    def jwt_conditions_valid!
+    def jwt_conditions_validate!
       conditions_results = CONDITIONS.map do |condition|
         condition.new(decoded_jwt).validate!
       end

--- a/lib/apple_sign_in/user_identity.rb
+++ b/lib/apple_sign_in/user_identity.rb
@@ -2,6 +2,7 @@
 
 module AppleSignIn
   class UserIdentity
+    class JWTValidationError < StandardError; end
     APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'
 
     attr_reader :user_identity, :jwt
@@ -11,10 +12,12 @@ module AppleSignIn
       @jwt = jwt
     end
 
-    def valid?
+    def validate
       token_data = decoded_jwt
 
-      JWTConditions.new(user_identity, token_data).valid?
+      raise JWTValidationError unless JWTConditions.new(user_identity, token_data).valid?
+
+      token_data.symbolize_keys
     end
 
     private

--- a/lib/apple_sign_in/user_identity.rb
+++ b/lib/apple_sign_in/user_identity.rb
@@ -2,8 +2,7 @@
 
 module AppleSignIn
   class UserIdentity
-    class JWTValidationError < StandardError; end
-    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'
+    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'.freeze
 
     attr_reader :user_identity, :jwt
 
@@ -15,7 +14,7 @@ module AppleSignIn
     def validate
       token_data = decoded_jwt
 
-      raise JWTValidationError unless JWTConditions.new(user_identity, token_data).valid?
+      JWTConditions.new(user_identity, token_data).validate!
 
       token_data.symbolize_keys
     end

--- a/lib/apple_sign_in/user_identity.rb
+++ b/lib/apple_sign_in/user_identity.rb
@@ -2,7 +2,7 @@
 
 module AppleSignIn
   class UserIdentity
-    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'.freeze
+    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'
 
     attr_reader :user_identity, :jwt
 
@@ -11,7 +11,7 @@ module AppleSignIn
       @jwt = jwt
     end
 
-    def validate
+    def validate!
       token_data = decoded_jwt
 
       JWTConditions.new(user_identity, token_data).validate!

--- a/spec/helpers/jwt_conditions_spec.rb
+++ b/spec/helpers/jwt_conditions_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AppleSignIn::JWTConditions do
   context '#valid?' do
     context 'when decoded jwt attributes are valid and user_identity is valid' do
       it 'returns true' do
-        expect(jwt_conditions_helper).to be_valid
+        expect(jwt_conditions_helper.validate!).to eq(true)
       end
     end
 
@@ -41,16 +41,20 @@ RSpec.describe AppleSignIn::JWTConditions do
       context 'when exp is not a integer' do
         let(:jwt_exp) { Time.now + 5.minutes }
 
-        it 'returns false' do
-          expect(jwt_conditions_helper).to_not be_valid
+        it 'raise an exception' do
+          expect { jwt_conditions_helper.validate! }.to raise_error(
+            AppleSignIn::Conditions::JWTValidationError
+          )
         end
       end
 
       context 'when exp is not a integer' do
         let(:jwt_iat) { Time.now }
 
-        it 'returns false' do
-          expect(jwt_conditions_helper).to_not be_valid
+        it 'raise an exception' do
+          expect { jwt_conditions_helper.validate! }.to raise_error(
+            AppleSignIn::Conditions::JWTValidationError
+          )
         end
       end
     end
@@ -58,40 +62,50 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt iss is different to user_identity' do
       let(:jwt_sub) { '1234.5678.911' }
 
-      it 'returns false' do
-        expect(jwt_conditions_helper).to_not be_valid
+      it 'raise an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleSignIn::Conditions::JWTValidationError
+        )
       end
     end
 
-    context 'when jwt_aud os different to apple_client_id' do
+    context 'when jwt_aud is different to apple_client_id' do
       let(:jwt_aud) { 'net.apple_sign_in' }
 
-      it 'returns false' do
-        expect(jwt_conditions_helper).to_not be_valid
+      it 'raise an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleSignIn::Conditions::JWTValidationError, 'jwt_aud is different to apple_client_id'
+        )
       end
     end
 
-    context 'when jwt_iss os different to apple_iss' do
+    context 'when jwt_iss is different to apple_iss' do
       let(:jwt_iss) { 'https://appleid.apple.net' }
 
-      it 'returns false' do
-        expect(jwt_conditions_helper).to_not be_valid
+      it 'raise an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleSignIn::Conditions::JWTValidationError, 'jwt_iss is different to apple_iss'
+        )
       end
     end
 
     context 'when jwt_exp is leasser than now' do
       let(:jwt_exp) { Time.now.to_i }
 
-      it 'returns false' do
-        expect(jwt_conditions_helper).to_not be_valid
+      it 'raise an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleSignIn::Conditions::JWTValidationError, 'Expired jwt_exp'
+        )
       end
     end
 
     context 'when jwt_iat is greater than now' do
       let(:jwt_iat) { (Time.now + 5.minutes).to_i }
 
-      it 'returns false' do
-        expect(jwt_conditions_helper).to_not be_valid
+      it 'raise an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleSignIn::Conditions::JWTValidationError, 'jwt_iat is greater than now'
+        )
       end
     end
   end

--- a/spec/helpers/jwt_conditions_spec.rb
+++ b/spec/helpers/jwt_conditions_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AppleSignIn::JWTConditions do
       context 'when exp is not a integer' do
         let(:jwt_exp) { Time.now + 5.minutes }
 
-        it 'raise an exception' do
+        it 'raises an exception' do
           expect { jwt_conditions_helper.validate! }.to raise_error(
             AppleSignIn::Conditions::JWTValidationError
           )
@@ -51,7 +51,7 @@ RSpec.describe AppleSignIn::JWTConditions do
       context 'when exp is not a integer' do
         let(:jwt_iat) { Time.now }
 
-        it 'raise an exception' do
+        it 'raises an exception' do
           expect { jwt_conditions_helper.validate! }.to raise_error(
             AppleSignIn::Conditions::JWTValidationError
           )
@@ -62,7 +62,7 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt iss is different to user_identity' do
       let(:jwt_sub) { '1234.5678.911' }
 
-      it 'raise an exception' do
+      it 'raises an exception' do
         expect { jwt_conditions_helper.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError
         )
@@ -72,7 +72,7 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt_aud is different to apple_client_id' do
       let(:jwt_aud) { 'net.apple_sign_in' }
 
-      it 'raise an exception' do
+      it 'raises an exception' do
         expect { jwt_conditions_helper.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError, 'jwt_aud is different to apple_client_id'
         )
@@ -82,7 +82,7 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt_iss is different to apple_iss' do
       let(:jwt_iss) { 'https://appleid.apple.net' }
 
-      it 'raise an exception' do
+      it 'raises an exception' do
         expect { jwt_conditions_helper.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError, 'jwt_iss is different to apple_iss'
         )
@@ -92,7 +92,7 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt_exp is leasser than now' do
       let(:jwt_exp) { Time.now.to_i }
 
-      it 'raise an exception' do
+      it 'raises an exception' do
         expect { jwt_conditions_helper.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError, 'Expired jwt_exp'
         )
@@ -102,7 +102,7 @@ RSpec.describe AppleSignIn::JWTConditions do
     context 'when jwt_iat is greater than now' do
       let(:jwt_iat) { (Time.now + 5.minutes).to_i }
 
-      it 'raise an exception' do
+      it 'raises an exception' do
         expect { jwt_conditions_helper.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError, 'jwt_iat is greater than now'
         )

--- a/spec/user_identity_spec.rb
+++ b/spec/user_identity_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AppleSignIn::UserIdentity do
       let(:uid) { user_identity }
 
       it 'returns the validated JWT attributes' do
-        expect(user_identity_service.validate).to eq(jwt)
+        expect(user_identity_service.validate!).to eq(jwt)
       end
 
       context 'when there are more than one private keys' do
@@ -58,7 +58,7 @@ RSpec.describe AppleSignIn::UserIdentity do
         let(:apple_body) { [exported_private_key] }
 
         it 'returns the validated JWT attributes' do
-          expect(user_identity_service.validate).to eq(jwt)
+          expect(user_identity_service.validate!).to eq(jwt)
         end
       end
     end
@@ -68,8 +68,8 @@ RSpec.describe AppleSignIn::UserIdentity do
       let(:user_identity) { '1234.5678.910' }
       let(:uid) { '1234.5678.911' }
 
-      it 'returns false' do
-        expect { user_identity_service.validate }.to raise_error(
+      it 'raises an exception' do
+        expect { user_identity_service.validate! }.to raise_error(
           AppleSignIn::Conditions::JWTValidationError
         )
       end

--- a/spec/user_identity_spec.rb
+++ b/spec/user_identity_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe AppleSignIn::UserIdentity do
       let(:user_identity) { '1234.5678.910' }
       let(:uid) { user_identity }
 
-      it 'returns true' do
-        expect(user_identity_service).to be_valid
+      it 'returns the validated JWT attributes' do
+        expect(user_identity_service.validate).to eq(jwt)
       end
 
       context 'when there are more than one private keys' do
@@ -54,12 +54,11 @@ RSpec.describe AppleSignIn::UserIdentity do
         let(:exported_private_key_two) do
           JWT::JWK::RSA.new(private_key).export.merge({ alg: 'RS256' })
         end
-        let(:apple_body) { [exported_private_key, exported_private_key_two] }
 
         let(:apple_body) { [exported_private_key] }
 
-        it 'verifies with the corresponding one' do
-          expect(user_identity_service).to be_valid
+        it 'returns the validated JWT attributes' do
+          expect(user_identity_service.validate).to eq(jwt)
         end
       end
     end
@@ -70,7 +69,9 @@ RSpec.describe AppleSignIn::UserIdentity do
       let(:uid) { '1234.5678.911' }
 
       it 'returns false' do
-        expect(user_identity_service).to_not be_valid
+        expect { user_identity_service.validate }.to raise_error(
+          AppleSignIn::UserIdentity::JWTValidationError
+        )
       end
     end
   end

--- a/spec/user_identity_spec.rb
+++ b/spec/user_identity_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AppleSignIn::UserIdentity do
 
       it 'returns false' do
         expect { user_identity_service.validate }.to raise_error(
-          AppleSignIn::UserIdentity::JWTValidationError
+          AppleSignIn::Conditions::JWTValidationError
         )
       end
     end


### PR DESCRIPTION
**This PR adds the possibility to see the decoded JWT data in the sign-in/up.** 
This is needed when integrating with devise, as there are attributes such as email that we need to retrieve from the JWT.

As the JWT needs to be decoded in order to be validated, then I thought that the function that validates the integrity of the JWT could also return the validated data (if valid, if not it would raise an error). If both were separated methods (lets say we have a new one that is named `decode`) then I couldn't think of a case where we would have to decode the data without validating it.

WDYT?